### PR TITLE
1.5.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.urbanmc</groupId>
     <artifactId>ezAuctions</artifactId>
-    <version>1.5.8-SNAPSHOT</version>
+    <version>1.5.9-SNAPSHOT</version>
 
     <name>ezAuctions</name>
     <url>http://urbanmc.net/</url>

--- a/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
+++ b/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
@@ -331,7 +331,12 @@ public class AuctionCommand extends BaseCommand {
 			}
 		}
 
-		MessageUtil.broadcastRegular(auc.getAuctioneer().getUniqueId(), Messages.getString("auction.end"));
+		String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auc.getWorld();
+
+		MessageUtil.broadcastRegular(auc.getAuctioneer().getUniqueId(), worldName, Messages.getString("auction.end"));
 
 		// Should never be false
 		if (EzAuctions.getAuctionManager().getCurrentRunnable() != null)

--- a/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
+++ b/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
@@ -23,11 +23,8 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @CommandAlias("auction|auctions|auc|ezauctions|ezauction")
 @CommandPermission("ezauctions.auction")
@@ -374,12 +371,16 @@ public class AuctionCommand extends BaseCommand {
 			return;
 		}
 
-		if (manager.getQueueSize() == ConfigManager.getConfig().getInt("general.auction-queue-limit")) {
+		if (manager.getQueueSize() >= ConfigManager.getConfig().getInt("general.auction-queue-limit")
+				&& manager.getQueueSize() >=
+				getPermissionLimit(p, "ezauctions\\.auction\\.queuelimit\\.([0-9]+)", 30)) {
 			sendPropMessage(p, "command.auction.start.queue_full");
 			return;
 		}
 
-		if (manager.inQueueOrCurrent(p.getUniqueId())) {
+		if (manager.inQueueOrCurrent(p.getUniqueId())
+				&& manager.getNumberInQueue(ap) >=
+				getPermissionLimit(p, "ezauctions\\.auction\\.currentlimit\\.([0-9]+)", 32)) {
 			sendPropMessage(p, "command.auction.start.in_queue");
 			return;
 		}
@@ -418,6 +419,34 @@ public class AuctionCommand extends BaseCommand {
 			int position = EzAuctions.getAuctionManager().getPositionInQueue(ap);
 			sendPropMessage(p, "command.auction.start.added_to_queue", position);
 		}
+	}
+
+	/**
+	 * Will find permisisons matching a regex of the pattern 'permission.#'
+	 * Must have a # for limit at the end of the permission
+	 * @param p Player to check permission for
+	 * @param regex regex for permission check
+	 * @param substringIndex index to substring to know where to find the limit number
+	 * @return The limit number from the permission or the highest one if multiple are present
+	 */
+	private int getPermissionLimit(Player p, String regex, int substringIndex) {
+		AtomicInteger maxLimit = new AtomicInteger();
+
+		// Go through each permission the player has to locate any queuelimit permissions
+		p.getEffectivePermissions().stream()
+				.map(info -> info.getPermission().toLowerCase())
+				// filter to permissions matching ezauctions.auction.queuelimit.#
+				.filter(permission -> permission.matches(regex))
+				.forEach(permission -> {
+					// substring to get rid of all characters preceding the number of the queuelimit
+					String number = permission.substring(substringIndex);
+					int limit = Integer.parseInt(number);
+
+					if (limit > maxLimit.get())
+						maxLimit.set(limit);
+				});
+
+		return maxLimit.get();
 	}
 
 	private BaseComponent[] getQueueMessage(int pos, Auction auc) {

--- a/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
+++ b/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
@@ -58,7 +58,7 @@ public class AuctionManager {
 		if (queue.isEmpty())
 			return -1;
 
-		int index = queue.indexOf(ap);
+		int index = queue.indexOfReverse(ap);
 
 		return index == -1 ? index : index + 1;
 	}

--- a/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
+++ b/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
@@ -129,6 +129,10 @@ public class AuctionManager {
 		return queue.iterator();
 	}
 
+	public int getNumberInQueue(AuctionsPlayer player) {
+		return queue.getNumberInQueue(player);
+	}
+
 	public void disabling() {
 		if (getCurrentRunnable() != null) {
 			getCurrentRunnable().cancelAuction();

--- a/src/main/java/net/urbanmc/ezauctions/object/Auction.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/Auction.java
@@ -114,7 +114,12 @@ public class Auction {
             String message = Messages.getInstance().getStringWithoutColoring("auction.bid", bidder, amount, "%item%",
                     getAmount(), getAuctionTime());
 
-            MessageUtil.broadcastSpammy(auctioneer.getUniqueId(), formatMessage(message));
+            String worldName = null;
+
+            if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+                worldName = getWorld();
+
+            MessageUtil.broadcastSpammy(auctioneer.getUniqueId(), worldName, formatMessage(message));
         }
 
         FileConfiguration data = ConfigManager.getConfig();

--- a/src/main/java/net/urbanmc/ezauctions/object/AuctionQueue.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/AuctionQueue.java
@@ -173,6 +173,19 @@ public class AuctionQueue {
         return -1;
     }
 
+    public int getNumberInQueue(AuctionsPlayer player) {
+        int numberInQueue = 0;
+
+        for (int i = 0; i < queue.length; ++i) {
+            Auction auction = queue[i];
+
+            if (auction != null && auction.getAuctioneer() == player)
+                numberInQueue++;
+        }
+
+        return numberInQueue;
+    }
+
     /**
      * Remove a specific index from the queue
      *

--- a/src/main/java/net/urbanmc/ezauctions/object/AuctionQueue.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/AuctionQueue.java
@@ -161,6 +161,18 @@ public class AuctionQueue {
         return -1;
     }
 
+    public int indexOfReverse(AuctionsPlayer player) {
+        for (int i = queue.length - 1; i >= 0; i--) {
+            Auction auction = queue[i];
+
+            if (auction != null && auction.getAuctioneer() == player) {
+                return distanceAwayFromHead(i);
+            }
+        }
+
+        return -1;
+    }
+
     public int indexOf(UUID player) {
         for (int i = 0; i < queue.length; ++i) {
             Auction auction = queue[i];

--- a/src/main/java/net/urbanmc/ezauctions/runnable/AuctionRunnable.java
+++ b/src/main/java/net/urbanmc/ezauctions/runnable/AuctionRunnable.java
@@ -58,7 +58,12 @@ public class AuctionRunnable extends BukkitRunnable {
     private void broadcastStart() {
         BaseComponent[] comp = getAuction().getStartingMessage();
 
-        MessageUtil.broadcastRegular(auctioneer, comp);
+        String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auction.getWorld();
+
+        MessageUtil.broadcastRegular(auctioneer, worldName, comp);
     }
 
     private void broadcastTime() {
@@ -67,7 +72,12 @@ public class AuctionRunnable extends BukkitRunnable {
         String broadcast = Messages.getInstance().getStringWithoutColoring("auction.time_left", timeLeft,
                 "%item%", auction.getAmount(), currentAmount);
 
-        MessageUtil.broadcastSpammy(auctioneer, auction.formatMessage(broadcast));
+        String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auction.getWorld();
+
+        MessageUtil.broadcastSpammy(auctioneer, worldName, auction.formatMessage(broadcast));
     }
 
     public Auction getAuction() {
@@ -86,7 +96,12 @@ public class AuctionRunnable extends BukkitRunnable {
 
         int addTime = data.getInt("antisnipe.time");
 
-        MessageUtil.broadcastSpammy(auctioneer, "auction.antisnipe", addTime);
+        String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auction.getWorld();
+
+        MessageUtil.broadcastSpammy(auctioneer, worldName, "auction.antisnipe", addTime);
         timeLeft += addTime;
 
         antiSnipeTimesRun++;
@@ -114,14 +129,24 @@ public class AuctionRunnable extends BukkitRunnable {
             String broadcast = Messages.getInstance().getStringWithoutColoring("auction.finish", lastBidderName,
                     lastBidAmount, "%item%", auc.getAmount());
 
-            MessageUtil.broadcastRegular(auctioneer, auc.formatMessage(broadcast));
+            String worldName = null;
+
+            if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+                worldName = auction.getWorld();
+
+            MessageUtil.broadcastRegular(auctioneer, worldName, auc.formatMessage(broadcast));
 
             RewardUtil.rewardAuction(auc, econ);
         } else {
             String broadcast = Messages.getInstance().getStringWithoutColoring("auction.finish.no_bids", "%item%",
                     getAuction().getAmount());
 
-            MessageUtil.broadcastRegular(auctioneer, getAuction().formatMessage(broadcast));
+            String worldName = null;
+
+            if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+                worldName = auction.getWorld();
+
+            MessageUtil.broadcastRegular(auctioneer, worldName, getAuction().formatMessage(broadcast));
             RewardUtil.rewardCancel(getAuction());
         }
     }
@@ -131,7 +156,12 @@ public class AuctionRunnable extends BukkitRunnable {
 
         ScoreboardManager.getInstance().removeBoards();
 
-        MessageUtil.broadcastRegular(auctioneer, "auction.cancelled");
+        String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auction.getWorld();
+
+        MessageUtil.broadcastRegular(auctioneer, worldName, "auction.cancelled");
         EzAuctions.getAuctionManager().next();
 
         RewardUtil.rewardCancel(getAuction());
@@ -142,7 +172,12 @@ public class AuctionRunnable extends BukkitRunnable {
 
         ScoreboardManager.getInstance().removeBoards();
 
-        MessageUtil.broadcastRegular(auctioneer, "auction.impounded");
+        String worldName = null;
+
+        if (ConfigManager.getConfig().getBoolean("auctions.per-world-broadcast"))
+            worldName = auction.getWorld();
+
+        MessageUtil.broadcastRegular(auctioneer, worldName, "auction.impounded");
         EzAuctions.getAuctionManager().next();
 
         RewardUtil.rewardImpound(getAuction(), impounder);

--- a/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
@@ -4,69 +4,90 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 import net.urbanmc.ezauctions.manager.AuctionsPlayerManager;
 import net.urbanmc.ezauctions.manager.Messages;
+import net.urbanmc.ezauctions.object.AuctionsPlayer;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import java.util.UUID;
+import java.util.stream.Stream;
 
 public class MessageUtil {
 
-    public static void broadcastRegular(UUID auctioneer, String prop, Object... args) {
-        String message = Messages.getString(prop, args);
+	public static void broadcastRegular(UUID auctioneer, String worldName, String prop, Object... args) {
+		String message = Messages.getString(prop, args);
 
-        Bukkit.getOnlinePlayers().stream().map(p -> AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId()))
-                .filter(ap -> !ap.isIgnoringAll() && !ap.getIgnoringPlayers().contains(auctioneer))
-                .forEach(ap -> ap.getOnlinePlayer().sendMessage(message));
+		Stream<AuctionsPlayer> playerStream = getPlayersToSendToRegular(auctioneer, worldName);
 
-        Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(message));
-    }
+		// send to proper players
+		playerStream.forEach(ap -> ap.getOnlinePlayer().sendMessage(message));
+		// send to console
+		Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(message));
+	}
 
-    public static void broadcastRegular(UUID auctioneer, BaseComponent... comp) {
-        Bukkit.getOnlinePlayers().stream().map(p -> AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId()))
-                .filter(ap -> !ap.isIgnoringAll() && !ap.getIgnoringPlayers().contains(auctioneer))
-                .forEach(ap -> ap.getOnlinePlayer().spigot().sendMessage(comp));
+	public static void broadcastRegular(UUID auctioneer, String worldName, BaseComponent[] comp) {
+		Stream<AuctionsPlayer> playerStream = getPlayersToSendToRegular(auctioneer, worldName);
 
-        Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
-    }
+		// send to proper players
+		playerStream.forEach(ap -> ap.getOnlinePlayer().spigot().sendMessage(comp));
+		// send to console
+		Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
+	}
 
-    public static void broadcastSpammy(UUID auctioneer, String prop, Object... args) {
-        String message = Messages.getString(prop, args);
+	public static void broadcastSpammy(UUID auctioneer, String worldName, String prop, Object... args) {
+		String message = Messages.getString(prop, args);
 
-        Bukkit.getOnlinePlayers().stream().map(p -> AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId()))
-                .filter(ap -> !ap.isIgnoringAll() && !ap.isIgnoringSpammy()
-                        && !ap.getIgnoringPlayers().contains(auctioneer))
-                .forEach(ap -> ap.getOnlinePlayer().sendMessage(message));
+		Stream<AuctionsPlayer> playerStream = getPlayersToSendToSpammy(auctioneer, worldName);
 
-        Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(message));
-    }
+		playerStream.forEach(ap -> ap.getOnlinePlayer().sendMessage(message));
+		Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(message));
+	}
 
-    public static void broadcastSpammy(UUID auctioneer, BaseComponent... comp) {
-        Bukkit.getOnlinePlayers().stream().map(p -> AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId()))
-                .filter(ap -> !ap.isIgnoringAll() && !ap.isIgnoringSpammy()
-                        && !ap.getIgnoringPlayers().contains(auctioneer))
-                .forEach(ap -> ap.getOnlinePlayer().spigot().sendMessage(comp));
+	public static void broadcastSpammy(UUID auctioneer, String worldName, BaseComponent... comp) {
+		Stream<AuctionsPlayer> playerStream = getPlayersToSendToSpammy(auctioneer, worldName);
 
-        Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
-    }
+		playerStream.forEach(ap -> ap.getOnlinePlayer().spigot().sendMessage(comp));
+		Bukkit.getConsoleSender().sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
+	}
 
-    public static void privateMessage(CommandSender sender, String prop, Object... args) {
-        String message = Messages.getString(prop, args);
+	private static Stream<AuctionsPlayer> getPlayersToSendToRegular(UUID auctioneer, String worldName) {
+		Stream<AuctionsPlayer> playerStream =
+				Bukkit.getOnlinePlayers().stream().map(p -> AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId()))
+						.filter(ap -> !ap.isIgnoringAll() && !ap.getIgnoringPlayers().contains(auctioneer));
 
-        if (sender instanceof Player) {
-            sender.sendMessage(message);
-        } else {
-            message = ChatColor.stripColor(message);
-            sender.sendMessage(message);
-        }
-    }
+		// if world name specified, match players to that world and only broadcast if they are in it
+		if (worldName != null) {
+			playerStream = playerStream.filter(ap -> ap.getOnlinePlayer().getWorld().getName().equals(worldName));
+		}
 
-    public static void privateMessage(CommandSender sender, BaseComponent... comp) {
-        if (sender instanceof Player) {
-            ((Player) sender).spigot().sendMessage(comp);
-        } else {
-            sender.sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
-        }
-    }
+		return playerStream;
+	}
+
+	private static Stream<AuctionsPlayer> getPlayersToSendToSpammy(UUID auctioneer, String worldName) {
+		Stream<AuctionsPlayer> playerStream = getPlayersToSendToRegular(auctioneer, worldName);
+
+		playerStream = playerStream.filter(ap -> !ap.isIgnoringSpammy());
+
+		return playerStream;
+	}
+
+	public static void privateMessage(CommandSender sender, String prop, Object... args) {
+		String message = Messages.getString(prop, args);
+
+		if (sender instanceof Player) {
+			sender.sendMessage(message);
+		} else {
+			message = ChatColor.stripColor(message);
+			sender.sendMessage(message);
+		}
+	}
+
+	public static void privateMessage(CommandSender sender, BaseComponent... comp) {
+		if (sender instanceof Player) {
+			((Player) sender).spigot().sendMessage(comp);
+		} else {
+			sender.sendMessage(ChatColor.stripColor(new TextComponent(comp).toPlainText()));
+		}
+	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -45,6 +45,9 @@ auctions:
   # receive items from the world where the auction was initiated
   # Winnings will be stored in the database until the player re-enters the proper world
   per-world-auctions: false
+  # This is intended for the per-world-auctions
+  # All auction messages will be limited to players inside the world in which the auction was started
+  per-world-broadcast: false
 
   # When should we broadcast the time left in the auction?
   broadcast-times: [45, 30, 15, 3, 2, 1]

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: net.urbanmc.ezauctions.EzAuctions
 name: ezAuctions
-version: 1.5.8
+version: 1.5.9
 api-version: 1.13
 authors: [Elian, Silverwolfg11]
 description: A simple, text-based auction plugin


### PR DESCRIPTION
* Added per-world-broadcast config option which limits broadcasts to players in the world which the auction was started in #5 
* Added support for permissions to bypass queue limits
  * ezauctions.auction.queuelimit.# to allow a bypass of the auction queue limit to that #
  * ezauctions.auction.currentlimit.# to allow a bypass of not being able to have more than one auction currently running or in queue
* Change spigot dependency from 1.16.1 to 1.16.5 (should have no effect on plugin)