### PR TITLE
1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.urbanmc</groupId>
     <artifactId>ezAuctions</artifactId>
-    <version>1.5.9-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
 
     <name>ezAuctions</name>
     <url>http://urbanmc.net/</url>
@@ -146,8 +146,8 @@
     </build>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.11</maven.compiler.source>
+        <maven.compiler.target>1.11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
+++ b/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
@@ -385,6 +385,22 @@ public class AuctionCommand extends BaseCommand {
 			return;
 		}
 
+		if (manager.hasCooldown(p.getUniqueId()) && !p.hasPermission("ezauctions.cooldownexempt")) {
+			long timeRequiredToWait = ConfigManager.getConfig().getLong("general.queue-cooldown-time");
+			long timeSinceLastAuction = manager.getTimeSinceLastAuction(p.getUniqueId());
+			long timeStillNeededToWait = timeRequiredToWait * 1000 - timeSinceLastAuction;
+
+			long minutes = (timeStillNeededToWait / 1000) / 60;
+			long seconds = (timeStillNeededToWait / 1000) % 60;
+
+			if (minutes > 0)
+				sendPropMessage(p, "command.auction.start.cooldown.time_minutes", seconds, minutes);
+			else
+				sendPropMessage(p, "command.auction.start.cooldown.time_seconds", seconds);
+
+			return;
+		}
+
 		if (!hasFee(p)) {
 			sendPropMessage(p, "command.auction.start.lacking_fee");
 			return;
@@ -410,6 +426,8 @@ public class AuctionCommand extends BaseCommand {
 
 		if (event.isCancelled())
 			return;
+
+		manager.setCooldown(p.getUniqueId());
 
 		removeFee(p);
 

--- a/src/main/java/net/urbanmc/ezauctions/listener/WorldChangeListener.java
+++ b/src/main/java/net/urbanmc/ezauctions/listener/WorldChangeListener.java
@@ -1,12 +1,18 @@
 package net.urbanmc.ezauctions.listener;
 
+import net.urbanmc.ezauctions.EzAuctions;
+import net.urbanmc.ezauctions.manager.AuctionManager;
 import net.urbanmc.ezauctions.manager.AuctionsPlayerManager;
+import net.urbanmc.ezauctions.manager.ConfigManager;
+import net.urbanmc.ezauctions.manager.ScoreboardManager;
 import net.urbanmc.ezauctions.object.AuctionsPlayer;
 import net.urbanmc.ezauctions.util.RewardUtil;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.scoreboard.Score;
 
 import java.util.UUID;
 
@@ -15,10 +21,22 @@ public class WorldChangeListener implements Listener {
 	// run reward offline when player changes worlds as well
 	@EventHandler
 	public void onPlayerChangedWorld(PlayerChangedWorldEvent e) {
-		UUID id = e.getPlayer().getUniqueId();
+		Player player = e.getPlayer();
+		UUID id = player.getUniqueId();
 		AuctionsPlayer ap = AuctionsPlayerManager.getInstance().getPlayer(id);
 
 		if (!ap.getOfflineItems().isEmpty())
 			RewardUtil.rewardOffline(ap);
+
+		// remove auctions board if moved to wrong world
+
+		String world = player.getWorld().getName();
+		String currentAuctionWorld = EzAuctions.getAuctionManager().getCurrentAuction().getWorld();
+
+		if (ConfigManager.getConfig().getStringList("blocked-worlds").contains(world))
+			player.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
+
+		if (ConfigManager.getConfig().getBoolean("per-world-broadcast") && !world.equals(currentAuctionWorld))
+			player.setScoreboard(Bukkit.getScoreboardManager().getNewScoreboard());
 	}
 }

--- a/src/main/java/net/urbanmc/ezauctions/manager/AuctionsPlayerManager.java
+++ b/src/main/java/net/urbanmc/ezauctions/manager/AuctionsPlayerManager.java
@@ -78,11 +78,15 @@ public class AuctionsPlayerManager {
     }
 
     public AuctionsPlayer getPlayer(UUID id) {
+        if (!players.containsKey(id)) {
+            createPlayer(id);
+        }
+
         return players.get(id);
     }
 
     public void createPlayer(UUID id) {
-        AuctionsPlayer ap = getPlayer(id);
+        AuctionsPlayer ap = players.get(id);
 
         if (ap == null) {
             ap = new AuctionsPlayer(id, false, false, false, new ArrayList<>(), new ArrayList<>());

--- a/src/main/java/net/urbanmc/ezauctions/manager/ScoreboardManager.java
+++ b/src/main/java/net/urbanmc/ezauctions/manager/ScoreboardManager.java
@@ -35,6 +35,10 @@ public class ScoreboardManager {
         return instance;
     }
 
+    public Scoreboard getBoard() {
+        return board;
+    }
+
     private void createScoreboard() {
         board = Bukkit.getScoreboardManager().getNewScoreboard();
 
@@ -92,6 +96,14 @@ public class ScoreboardManager {
 
         for (Player p : Bukkit.getOnlinePlayers()) {
             AuctionsPlayer ap = AuctionsPlayerManager.getInstance().getPlayer(p.getUniqueId());
+
+            String world = ap.getOnlinePlayer().getWorld().getName();
+
+            if (ConfigManager.getConfig().getStringList("blocked-worlds").contains(world))
+                continue;
+
+            if (ConfigManager.getConfig().getBoolean("per-world-broadcast") && !world.equals(auc.getWorld()))
+                continue;
 
             if (ap.isIgnoringScoreboard() || ap.getIgnoringPlayers().contains(auc.getAuctioneer().getUniqueId()))
                 continue;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -24,6 +24,11 @@ general:
   minimum-cancel-time: 20
   # What is the maximum amount of auctions that can be in the queue
   auction-queue-limit: 3
+  # When putting auctions into the queue, what is the time in seconds that the player must wait before they
+  # are allowed to start an auction again?
+  # Set to 0 to disable
+  # use ezauctions.cooldownexempt permission to bypass this
+  queue-cooldown-time: 0
 
 auctions:
   # Worlds that you cannot start auctions in
@@ -50,7 +55,7 @@ auctions:
   per-world-broadcast: false
 
   # When should we broadcast the time left in the auction?
-  broadcast-times: [45, 30, 15, 3, 2, 1]
+  broadcast-times: [ 45, 30, 15, 3, 2, 1 ]
 
   fees:
     # The price it costs to start an auction (set to 0 for no price)

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -77,6 +77,11 @@ command.auction.start.invalid_start_price.max={prefix}&cStarting price is too hi
 command.auction.start.invalid-inc={prefix}&cInvalid Increment!
 command.auction.start.invalid-buyout={prefix}&cInvalid Buyout Amount!
 command.auction.start.invalid-time={prefix}&cInvalid Time!
+# {0} is the seconds left in the cooldown
+command.auction.start.cooldown.time_seconds={prefix}&cYou must wait {0} seconds to start another auction!
+# {0} is the seconds left in the cooldown
+# {1} is the minutes left in the cooldown
+command.auction.start.cooldown.time_minutes={prefix}&cYou must wait {1} minutes and {0} seconds to start another auction!
 # {0} is their position in the queue
 command.auction.start.added_to_queue={prefix}&9You are position {0} in the queue.
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: net.urbanmc.ezauctions.EzAuctions
 name: ezAuctions
-version: 1.5.9
+version: 1.6.0
 api-version: 1.13
 authors: [Elian, Silverwolfg11]
 description: A simple, text-based auction plugin
@@ -82,4 +82,6 @@ permissions:
   ezauctions.updatemessage:
     default: false
   ezauctions.taxexempt:
+    default: false
+  ezauctions.cooldownexempt:
     default: false


### PR DESCRIPTION
- Bumped Java version to 11
- Added safety check when getting auction player to ensure they have player data created
- No longer show auction scoreboards to players in blocked auction worlds or in worlds where the player is not in the originating world of the auction when per-world-broadcast is enabled
- Added configurable auction queue cooldown that limits how often players can start auctions