### PR TITLE
Fix missing help message for /auction end.

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -99,6 +99,7 @@ command.auction.queue.list={prefix} &9Auction Queue:
 command.auction.queue.empty=&bNo auctions in the queue!
 command.auction.queue.item=&b{0}. &9{1} &a{2} &9starting at &6${3} &9by &e{4}
 
+command.auction.end.help=&b/auction end &1: &9Forcefully end the current auction.
 command.auction.end.attempt-others={prefix}&4You do not have permission to end other players'' auctions!
 
 command.bid.help=&b/bid [amount] &1: &9Place a bid on the current auction.


### PR DESCRIPTION
Adds help key for `/auction end`. The proposed help message is "Forcefully end the current auction."

Closes #17 