### PR TITLE
Create scheduler wrapper to fix shutdown errors.

### DIFF
--- a/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
+++ b/src/main/java/net/urbanmc/ezauctions/manager/AuctionManager.java
@@ -120,7 +120,7 @@ public class AuctionManager {
 
 			inDelayedTask = true;
 
-			Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> {
+			EzAuctions.getScheduler().runSyncDelayedTask( () -> {
 				currentRunnable = new AuctionRunnable(auction, plugin);
 				inDelayedTask = false;
 			}, delay);

--- a/src/main/java/net/urbanmc/ezauctions/object/TaskScheduler.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/TaskScheduler.java
@@ -1,0 +1,49 @@
+package net.urbanmc.ezauctions.object;
+
+import net.urbanmc.ezauctions.EzAuctions;
+import org.bukkit.Bukkit;
+
+// A simple scheduler wrapper that keeps track of when the plugin is shutting down
+// to avoid scheduling tasks on shutdown.
+// Without this wrapper, scheduling tasks on shutdown will throw errors.
+public class TaskScheduler {
+
+    private final EzAuctions plugin;
+    private boolean shuttingDown = false;
+
+    public TaskScheduler(EzAuctions plugin) {
+        this.plugin = plugin;
+    }
+
+    public void markShutdown() {
+        this.shuttingDown = true;
+    }
+
+    public void runSyncTask(Runnable run) {
+        if (shuttingDown) {
+            run.run();
+        }
+        else {
+            Bukkit.getScheduler().runTask(plugin, run);
+        }
+    }
+
+    public void runSyncDelayedTask(Runnable run, long delay) {
+        if (shuttingDown) {
+            run.run();
+        }
+        else {
+            Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, run, delay);
+        }
+    }
+
+    public void runAsyncTask(Runnable run) {
+        if (shuttingDown) {
+            run.run();
+        }
+        else {
+            Bukkit.getScheduler().runTaskAsynchronously(plugin, run);
+        }
+    }
+
+}

--- a/src/main/java/net/urbanmc/ezauctions/util/RewardUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/RewardUtil.java
@@ -20,8 +20,7 @@ public class RewardUtil {
 
 	public static void rewardAuction(Auction auction, Economy econ) {
 		// run async since we will be calling vault with offline player
-		Plugin plugin = Bukkit.getPluginManager().getPlugin("ezAuctions");
-		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+		EzAuctions.getScheduler().runAsyncTask( () -> {
 			Bidder lastBid = auction.getLastBidder();
 
 			OfflinePlayer auctioneer = auction.getAuctioneer().getOfflinePlayer();
@@ -56,7 +55,7 @@ public class RewardUtil {
 
 			returnBidderMoney(auction.getBidList(), false);
 
-			Bukkit.getScheduler().runTask(plugin, () -> {
+			EzAuctions.getScheduler().runSyncTask( () -> {
 				if (bidder.isOnline()) {
 					Player p = lastBid.getBidder().getOnlinePlayer();
 
@@ -98,8 +97,7 @@ public class RewardUtil {
 
 	private static void returnBidderMoney(BidList bidList, boolean allBidders) {
 		// run async since we will be calling vault with offline player
-		Plugin plugin = Bukkit.getPluginManager().getPlugin("ezAuctions");
-		Bukkit.getScheduler().runTaskAsynchronously(plugin, () -> {
+		EzAuctions.getScheduler().runAsyncTask( () -> {
 			bidList.forEach((bidder) -> EzAuctions.getEcon().depositPlayer(bidder.getBidder().getOfflinePlayer(),
 							bidder.getAmount()),
 					0, bidList.size() - (allBidders ? 0 : 1));


### PR DESCRIPTION
Scheduling tasks (espicially async tasks on plugin disable) caused several errors to be thrown. This PR creates a dedicated object to handle task scheduling which includes keeping track of when the plugin is shutting down and immediately running those tasks instead of scheduling them.

Closes #21