### PR TITLE
1.6.8

### DIFF
--- a/.github/workflows/automatic-release.yml
+++ b/.github/workflows/automatic-release.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           java-version: 1.17
 
-      # download latest buildtools and get remapped spigot jar
-      - run: wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-      - run: java -jar BuildTools.jar --rev 1.18 --remapped
-
       # build jar with maven
       - run: mvn --batch-mode --update-snapshots verify
 
@@ -34,5 +30,5 @@ jobs:
           # Release name will default to tag name
           # Tag name will be the name of the branch
           tag_name: ${{ github.head_ref }}
-          files: "./target/ezAuctions*-SNAPSHOT.jar"
+          files: "./target/ezAuctions*.jar"
           fail_on_unmatched_files: true

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -13,10 +13,6 @@ jobs:
         with:
           java-version: 1.17
 
-      # download latest buildtools and get remapped spigot jar
-      - run: wget https://hub.spigotmc.org/jenkins/job/BuildTools/lastSuccessfulBuild/artifact/target/BuildTools.jar
-      - run: java -jar BuildTools.jar --rev 1.18 --remapped
-
       - run: mvn --batch-mode --update-snapshots verify
       - uses: actions/upload-artifact@v2
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.urbanmc</groupId>
     <artifactId>ezAuctions</artifactId>
-    <version>1.6.7-SNAPSHOT</version>
+    <version>1.6.8</version>
 
     <name>ezAuctions</name>
     <url>http://urbanmc.net/</url>
@@ -62,6 +62,15 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>plugin.yml</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18-R0.1-SNAPSHOT</version>
+            <version>1.19.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -46,18 +46,18 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>2.2.1</version>
+            <version>3.0.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.0.0</version>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>co.aikar</groupId>
             <artifactId>acf-paper</artifactId>
-            <version>0.5.0-SNAPSHOT</version>
+            <version>0.5.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
+++ b/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
@@ -127,6 +127,11 @@ public class EzAuctions extends JavaPlugin {
 
 	@Override
 	public void onDisable() {
+		// if the scheduler is null, the plugin did not initialize due to vault/econ provider missing
+		// do not need to do any disable logic
+		if (scheduler == null)
+			return;
+
 		scheduler.markShutdown();
 		// Make sure auction manager is valid
 		if (getAuctionManager() != null)

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: net.urbanmc.ezauctions.EzAuctions
 name: ezAuctions
-version: 1.6.7
+version: ${project.version}
 api-version: 1.13
 authors: [Elian, Silverwolfg11]
 description: A simple, text-based auction plugin


### PR DESCRIPTION
- Remove warning messages triggered by ACF #27 by updating dependency version
- Resolve exception thrown to console when the plugin is loaded without vault/econ provider