### PR TITLE
Fix exception when loading plugin without Vault installed

### DIFF
--- a/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
+++ b/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
@@ -143,6 +143,9 @@ public class EzAuctions extends JavaPlugin {
 	}
 
 	private boolean setupEconomy() {
+		if (getServer().getPluginManager().getPlugin("Vault") == null)
+			return false;
+
 		try {
 			RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
 


### PR DESCRIPTION
An exception is generated when loading the plugin without Vault. This will ensure that the Vault plugin exists without generating an exception.