### PR TITLE
Support hex colors in chat messages

### DIFF
--- a/src/main/java/net/urbanmc/ezauctions/object/Auction.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/Auction.java
@@ -250,9 +250,8 @@ public class Auction {
     public BaseComponent[] formatMessage(String message) {
         if (message.contains("%item%")) {
             String[] split = message.split("%item%");
-            BaseComponent[] first = TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', split[0])),
-                    second = TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&',
-                            split[1]));
+            BaseComponent[] first = TextComponent.fromLegacyText(Messages.translateAllColors(split[0]));
+            BaseComponent[] second = TextComponent.fromLegacyText(Messages.translateAllColors(split[1]));
 
             BaseComponent lastComp = first[first.length - 1];
 
@@ -295,7 +294,7 @@ public class Auction {
 
             return combined;
         } else {
-            return TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', message));
+            return TextComponent.fromLegacyText(Messages.translateAllColors(message));
         }
     }
 }

--- a/src/main/java/net/urbanmc/ezauctions/util/ReflectionUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/ReflectionUtil.java
@@ -34,6 +34,10 @@ public class ReflectionUtil {
         }
     }
 
+    public static double getVersion() {
+        return version;
+    }
+
     public static String getMinecraftName(ItemStack is) {
         try {
             if (version >= 1.18) {
@@ -71,13 +75,13 @@ public class ReflectionUtil {
      */
     public static int getXPForRepair(ItemStack is) {
         try {
-            Object nmsStack = asNMSCopy(is);
-
             if (version >= 1.18) {
                 int cost = (int) is.getItemMeta().serialize().getOrDefault("repair-cost", 0);
                 boolean repairable = cost <= 40;
                 return repairable ? cost : -1;
             }
+
+            Object nmsStack = asNMSCopy(is);
 
             boolean hasTag = (boolean) nmsStack.getClass().getMethod("hasTag").invoke(nmsStack);
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,6 @@
 # ezAuctions Language File
 # DO NOT REMOVE ANY OF THESE! IT WILL THROW ERRORS
+# You can use hex colors too! Specify them as such: &#[hex value], example: &#FF0000 will be translated to red
 prefix='&f[&9Auction&f] '
 
 # Commands


### PR DESCRIPTION
Hex colors are now supported in the messages.properties file. Hex colors can be specified as such: &#[hex value], example: &#FF0000 will be translated to red