### PR TITLE
Allow reordering of help page list

### DIFF
--- a/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
+++ b/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
@@ -39,15 +39,8 @@ public class AuctionCommand extends BaseCommand {
 		List<String> display = new ArrayList<>();
 
 		for (RegisteredCommand sub : subs) {
-			Iterator<String> perms = sub.getRequiredPermissions().iterator();
-			perms.next();
-
-			if (!perms.hasNext())
-				continue;
-
-			String permission = perms.next();
-
-			if (!sender.hasPermission(permission))
+			Set<?> set = sub.getRequiredPermissions();
+			if (set.stream().anyMatch(s -> !sender.hasPermission((String)s)))
 				continue;
 
 			String[] split = sub.getCommand().split(" ");

--- a/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
@@ -75,6 +75,10 @@ public class MessageUtil {
 	public static void privateMessage(CommandSender sender, String prop, Object... args) {
 		String message = Messages.getString(prop, args);
 
+		// ignore if message empty
+		if (message.isEmpty())
+			return;
+
 		if (sender instanceof Player) {
 			sender.sendMessage(message);
 		} else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -152,3 +152,26 @@ scoreboard:
     - skull
     - repair
     - sealed
+
+help:
+  # this allows you to set the order in which commands appear when the auction help page is shown
+  # if the player does not have permission for the command, it will not be shown
+  # removing these will stop the help from showing for that command.
+  order:
+    - cancel
+    - disable
+    - enable
+    - end
+    - ignore
+    - ignoreplayer
+    - impound
+    - info
+    - queue
+    - reload
+    - remove
+    - save
+    - scoreboard
+    - spam
+    - start
+    - startsealed
+    - bid


### PR DESCRIPTION
The order of commands in the /auctions help page can now be changed via the config.

While working on this I discovered that it was possible for some commands to be shown in the help page that the user does not have access to. This should be resolved now.

Also added ability to disable *most* messages by setting the value in the message.properties to empty.