### PR TITLE
1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.urbanmc</groupId>
     <artifactId>ezAuctions</artifactId>
-    <version>1.6.8</version>
+    <version>1.7.0</version>
 
     <name>ezAuctions</name>
     <url>http://urbanmc.net/</url>

--- a/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
+++ b/src/main/java/net/urbanmc/ezauctions/EzAuctions.java
@@ -143,6 +143,9 @@ public class EzAuctions extends JavaPlugin {
 	}
 
 	private boolean setupEconomy() {
+		if (getServer().getPluginManager().getPlugin("Vault") == null)
+			return false;
+
 		try {
 			RegisteredServiceProvider<Economy> rsp = getServer().getServicesManager().getRegistration(Economy.class);
 

--- a/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
+++ b/src/main/java/net/urbanmc/ezauctions/command/AuctionCommand.java
@@ -21,6 +21,7 @@ import net.urbanmc.ezauctions.util.RewardUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
 
 import java.util.*;
@@ -38,15 +39,8 @@ public class AuctionCommand extends BaseCommand {
 		List<String> display = new ArrayList<>();
 
 		for (RegisteredCommand sub : subs) {
-			Iterator<String> perms = sub.getRequiredPermissions().iterator();
-			perms.next();
-
-			if (!perms.hasNext())
-				continue;
-
-			String permission = perms.next();
-
-			if (!sender.hasPermission(permission))
+			Set<?> set = sub.getRequiredPermissions();
+			if (set.stream().anyMatch(s -> !sender.hasPermission((String)s)))
 				continue;
 
 			String[] split = sub.getCommand().split(" ");
@@ -59,18 +53,42 @@ public class AuctionCommand extends BaseCommand {
 				display.add(subCommand);
 		}
 
-		Collections.sort(display);
+		if (sender.hasPermission("ezauctions.bid")) {
+			display.add("bid");
+		}
 
 		sendPropMessage(sender, "command.help");
 
+		display = getCommandOrder(display);
+
 		for (String command : display) {
-			String message = "command.auction." + command + ".help";
-			sendPropMessage(sender, message);
+			if (command.equals("bid")) {
+				sendPropMessage(sender, "command.bid.help");
+			} else {
+				String message = "command.auction." + command + ".help";
+				sendPropMessage(sender, message);
+			}
+		}
+	}
+
+	/**
+	 * Returns the subcommands in the order specified from the config help section
+	 * @param allowedCommands list of commands that the sender has access to
+	 */
+	private List<String> getCommandOrder(List<String> allowedCommands) {
+		ConfigurationSection helpSection = ConfigManager.getConfig().getConfigurationSection("help");
+
+		// using old config version, just display the help page in the order it used to: sorted, and bid at the end
+		if (helpSection == null) {
+			allowedCommands.remove("bid");
+			Collections.sort(allowedCommands);
+			allowedCommands.add("bid");
+			return allowedCommands;
 		}
 
-		if (sender.hasPermission("ezauctions.bid")) {
-			sendPropMessage(sender, "command.bid.help");
-		}
+		List<String> ordered = helpSection.getStringList("order");
+		ordered.removeIf(command -> !allowedCommands.contains(command));
+		return ordered;
 	}
 
 	@Subcommand("cancel|c")

--- a/src/main/java/net/urbanmc/ezauctions/object/Auction.java
+++ b/src/main/java/net/urbanmc/ezauctions/object/Auction.java
@@ -250,9 +250,8 @@ public class Auction {
     public BaseComponent[] formatMessage(String message) {
         if (message.contains("%item%")) {
             String[] split = message.split("%item%");
-            BaseComponent[] first = TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', split[0])),
-                    second = TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&',
-                            split[1]));
+            BaseComponent[] first = TextComponent.fromLegacyText(Messages.translateAllColors(split[0]));
+            BaseComponent[] second = TextComponent.fromLegacyText(Messages.translateAllColors(split[1]));
 
             BaseComponent lastComp = first[first.length - 1];
 
@@ -295,7 +294,7 @@ public class Auction {
 
             return combined;
         } else {
-            return TextComponent.fromLegacyText(ChatColor.translateAlternateColorCodes('&', message));
+            return TextComponent.fromLegacyText(Messages.translateAllColors(message));
         }
     }
 }

--- a/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/MessageUtil.java
@@ -75,6 +75,10 @@ public class MessageUtil {
 	public static void privateMessage(CommandSender sender, String prop, Object... args) {
 		String message = Messages.getString(prop, args);
 
+		// ignore if message empty
+		if (message.isEmpty())
+			return;
+
 		if (sender instanceof Player) {
 			sender.sendMessage(message);
 		} else {

--- a/src/main/java/net/urbanmc/ezauctions/util/ReflectionUtil.java
+++ b/src/main/java/net/urbanmc/ezauctions/util/ReflectionUtil.java
@@ -34,6 +34,10 @@ public class ReflectionUtil {
         }
     }
 
+    public static double getVersion() {
+        return version;
+    }
+
     public static String getMinecraftName(ItemStack is) {
         try {
             if (version >= 1.18) {
@@ -71,13 +75,13 @@ public class ReflectionUtil {
      */
     public static int getXPForRepair(ItemStack is) {
         try {
-            Object nmsStack = asNMSCopy(is);
-
             if (version >= 1.18) {
                 int cost = (int) is.getItemMeta().serialize().getOrDefault("repair-cost", 0);
                 boolean repairable = cost <= 40;
                 return repairable ? cost : -1;
             }
+
+            Object nmsStack = asNMSCopy(is);
 
             boolean hasTag = (boolean) nmsStack.getClass().getMethod("hasTag").invoke(nmsStack);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -152,3 +152,26 @@ scoreboard:
     - skull
     - repair
     - sealed
+
+help:
+  # this allows you to set the order in which commands appear when the auction help page is shown
+  # if the player does not have permission for the command, it will not be shown
+  # removing these will stop the help from showing for that command.
+  order:
+    - cancel
+    - disable
+    - enable
+    - end
+    - ignore
+    - ignoreplayer
+    - impound
+    - info
+    - queue
+    - reload
+    - remove
+    - save
+    - scoreboard
+    - spam
+    - start
+    - startsealed
+    - bid

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,6 @@
 # ezAuctions Language File
 # DO NOT REMOVE ANY OF THESE! IT WILL THROW ERRORS
+# You can use hex colors too! Specify them as such: &#[hex value], example: &#FF0000 will be translated to red
 prefix='&f[&9Auction&f] '
 
 # Commands


### PR DESCRIPTION
- Hex colors are now supported in the messages.properties file. Hex colors can be specified as such: &#[hex value], example: &#FF0000 will be translated to red
- The order of commands in the /auctions help page can now be changed via the config
- Ensure that only commands the player has permission to use will be shown in the help
- Added ability to disable *most* messages by setting the value in the message.properties to empty
- Fix exception when loading plugin without Vault installed