### PR TITLE
Fix exception from MiniMessage when item has colors in name/lore

### DIFF
--- a/src/main/java/me/elian/ezauctions/controller/MessageController.java
+++ b/src/main/java/me/elian/ezauctions/controller/MessageController.java
@@ -310,7 +310,7 @@ public class MessageController extends FileHandler {
 		replaced = replaced.replace("<itemamount>", Integer.toString(data.getAmount()));
 		replaced = replaced.replace("<minecraftname>", data.getMinecraftName());
 		replaced = replaced.replace("<customname>", data.getCustomName());
-		replaced = replaced.replace("<itemnbt>", data.getItemNbt());
+		replaced = replaced.replace("<itemnbt>", "");
 		return replaced;
 	}
 

--- a/src/main/java/me/elian/ezauctions/model/Auction.java
+++ b/src/main/java/me/elian/ezauctions/model/Auction.java
@@ -189,7 +189,11 @@ public class Auction implements Runnable {
 
 	private void cancelRepeatingTask() {
 		running = false;
-		repeatingTask.cancel();
+
+		if (repeatingTask != null) {
+			repeatingTask.cancel();
+		}
+
 		scoreboard.remove();
 		completedRunnable.run();
 	}

--- a/src/main/java/me/elian/ezauctions/model/AuctionData.java
+++ b/src/main/java/me/elian/ezauctions/model/AuctionData.java
@@ -5,6 +5,7 @@ import me.elian.ezauctions.controller.ConfigController;
 import me.elian.ezauctions.controller.MessageController;
 import me.elian.ezauctions.helper.ItemHelper;
 import me.elian.ezauctions.scheduler.TaskScheduler;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Formatter;
@@ -12,6 +13,7 @@ import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -36,6 +38,7 @@ public final class AuctionData {
 	private String itemNbt;
 	private String minecraftName;
 	private String customName;
+	private Key itemKey;
 
 	public AuctionData(AuctionPlayer auctioneer, ItemStack item, String amountString, int startingAuctionTime,
 	                   double startingPrice, double incrementPrice, double autoBuyPrice, boolean isSealed,
@@ -107,6 +110,10 @@ public final class AuctionData {
 		return customName;
 	}
 
+	public Key getItemKey() {
+		return itemKey;
+	}
+
 	public void gatherAdditionalData(Logger logger) {
 		if (item == null || item.getType() == Material.AIR)
 			return;
@@ -128,6 +135,9 @@ public final class AuctionData {
 			itemNbt = "";
 			logger.severe("Could not get item NBT! Item hover will not work correctly!", e);
 		}
+
+		NamespacedKey typeKey = item.getType().getKey();
+		itemKey = Key.key(typeKey.getNamespace(), typeKey.getKey());
 
 		minecraftName = ItemHelper.getMinecraftName(item);
 		customName = minecraftName;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -98,7 +98,7 @@ command.auction.queue.list={prefix} <blue>Auction Queue:
 command.auction.queue.empty=<aqua>No auctions in the queue!
 # the same values that are in the auction paramater block are available here
 # <position> is the position in the queue
-command.auction.queue.item=<aqua><position>. <green><itemamount> <aqua><hover:show_item:<materialtype>:<itemamount>:"<itemnbt>"><hascustomname><i><customname></i></hascustomname><nocustomname><lang:<minecraftname>></nocustomname><skull> <green>(Head of <white><skullowner></white>)<green></skull></hover> <blue>starting at <gold><startingprice> <blue>by <yellow><hover:show_entity:player:"<auctioneeruuid>"><auctioneer></hover>
+command.auction.queue.item=<aqua><position>. <green><itemamount> <aqua><hover:show_item:<materialtype>:<itemamount>:""><hascustomname><i><customname></i></hascustomname><nocustomname><lang:<minecraftname>></nocustomname><skull> <green>(Head of <white><skullowner></white>)<green></skull></hover> <blue>starting at <gold><startingprice> <blue>by <yellow><hover:show_entity:player:"<auctioneeruuid>"><auctioneer></hover>
 
 command.auction.end.help=<hover:show_text:"/auction end"><click:suggest_command:"/auction end"><aqua>/auction end <dark_blue>: <blue>Forcefully end the current auction.</click></hover>
 command.auction.end.attempt-others={prefix}<dark_red>You do not have permission to end other players' auctions!

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -119,7 +119,6 @@ command.bid.help=<hover:show_text:"/bid"><click:suggest_command:"/bid "><aqua>/b
 # <minecraftname> is the translatable minecraft name of the item being auctioned
 # <customname> is the custom name (translatable minecraft name if no custom name specified) of the item being auctioned
 # <materialtype> is material type of the item being auctioned
-# <itemnbt> is the nbt of the item being auctioned
 # <startingprice> is the starting price
 # <highestbidamount> is the highest bid (starting price if no bids or sealed auction)
 # <highestbidder> is the highest bidder name (blank if no bids or sealed auction)
@@ -137,7 +136,7 @@ command.bid.help=<hover:show_text:"/bid"><click:suggest_command:"/bid "><aqua>/b
 # <sealed></sealed> -> everything inside will be blank if the auction is not sealed
 # <repair></repair> -> everything inside will be blank if the item does not have a work penalty
 # <unrepairable></unrepairable> -> everything inside will be blank if the item is not repairable
-auction.info={prefix}<yellow><hover:show_entity:player:"<auctioneeruuid>"><auctioneer></hover> <blue>is auctioning <green><itemamount> <aqua><hover:show_item:<materialtype>:<itemamount>:"<itemnbt>"><hascustomname><i><customname></i></hascustomname><nocustomname><lang:<minecraftname>></nocustomname><skull> <green>(Head of <white><skullowner></white>)<green></skull></hover> <blue>for <gold>$<highestbidamount> <blue>at an increment of <gold>$<increment> <blue>for <green><remainingtime> <blue>seconds.\
+auction.info={prefix}<yellow><hover:show_entity:player:"<auctioneeruuid>"><auctioneer></hover> <blue>is auctioning <green><itemamount> <aqua><hover:show_item:<materialtype>:<itemamount>:""><hascustomname><i><customname></i></hascustomname><nocustomname><lang:<minecraftname>></nocustomname><skull> <green>(Head of <white><skullowner></white>)<green></skull></hover> <blue>for <gold>$<highestbidamount> <blue>at an increment of <gold>$<increment> <blue>for <green><remainingtime> <blue>seconds.\
   <unrepairable><newline><blue>This item cannot be repaired.</unrepairable><repair><newLine><blue>This item has a prior work penalty of <green><repairprice><blue> levels.</repair>\
   <autobuy><newline><blue>The auto-buy of this auction is set at <gold>$<autobuy><blue></autobuy>\
   <sealed><newline><blue>This is a sealed auction. Bids will not be disclosed.</sealed>


### PR DESCRIPTION
An exception can be generated by MiniMessage when item NBT contains the section character to add color to name/lore. This error serves no purpose and is not easily disabled, so reconstructing of the components with nbt filled in afterwards was necessary as a workaround.