### PR TITLE
Fix 1.20.4 and 1.20.6 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,21 +103,21 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-api</artifactId>
-            <version>2.0.0-RC11</version>
+            <version>2.1.10</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-implementation</artifactId>
-            <version>2.0.0-RC11</version>
+            <version>2.1.10</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.megavexnetwork.scoreboard-library</groupId>
+            <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-modern</artifactId>
-            <version>2.0.0-RC11</version>
+            <version>2.1.10</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>
@@ -178,6 +178,10 @@
                         <relocation>
                             <pattern>co.aikar.locales</pattern>
                             <shadedPattern>me.elian.ezauctions.locales</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>net.megavex.scoreboardlibrary</pattern>
+                            <shadedPattern>me.elian.ezauctions.scoreboardlibrary</shadedPattern>
                         </relocation>
                     </relocations>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -93,13 +93,13 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-minimessage</artifactId>
-            <version>4.14.0</version>
+            <version>4.17.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-platform-bukkit</artifactId>
-            <version>4.3.0</version>
+            <version>4.3.3</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/elian/ezauctions/controller/AuctionController.java
+++ b/src/main/java/me/elian/ezauctions/controller/AuctionController.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import me.elian.ezauctions.Logger;
+import me.elian.ezauctions.helper.ItemHelper;
 import me.elian.ezauctions.model.Auction;
 import me.elian.ezauctions.model.AuctionData;
 import me.elian.ezauctions.model.AuctionPlayer;
@@ -16,6 +17,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.function.UnaryOperator;
 
 @Singleton
 public class AuctionController implements Listener {
@@ -218,11 +220,19 @@ public class AuctionController implements Listener {
 		if (!config.getConfig().getBoolean("general.log-items-to-console"))
 			return;
 
+		String itemNbt;
+		try {
+			itemNbt = ItemHelper.getItemNBT(data.getItem());
+		} catch (Exception e) {
+			logger.warning("Unable to get auction item's NBT! Exception: " + e);
+			itemNbt = "{}";
+		}
+
 		logger.info(String.format(
 				message,
 				data.getAuctioneer().getOfflinePlayer().getName(),
 				data.getAmount(),
 				data.getItem().getType(),
-				data.getItemNbt()));
+				itemNbt));
 	}
 }

--- a/src/main/java/me/elian/ezauctions/controller/MessageController.java
+++ b/src/main/java/me/elian/ezauctions/controller/MessageController.java
@@ -5,8 +5,8 @@ import co.aikar.locales.MessageKey;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.elian.ezauctions.Logger;
+import me.elian.ezauctions.helper.ItemHelper;
 import me.elian.ezauctions.model.*;
-import net.kyori.adventure.nbt.api.BinaryTagHolder;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -209,8 +209,9 @@ public class MessageController extends FileHandler {
 			HoverEvent.ShowItem showItem = (HoverEvent.ShowItem) hoverEvent.value();
 			if (showItem.item().compareTo(data.getItemKey()) == 0
 					&& (showItem.nbt() == null || showItem.nbt().string().isEmpty())) {
-				HoverEvent<HoverEvent.ShowItem> newHoverEvent = HoverEvent.showItem(data.getItemKey(),
-						data.getAmount(), BinaryTagHolder.binaryTagHolder(data.getItemNbt()));
+				HoverEvent<HoverEvent.ShowItem> newHoverEvent = ItemHelper.getItemHover(data.getItem(),
+						initialEvent -> initialEvent.item(data.getItemKey())
+										.count(data.getAmount()));
 				returnComponent = returnComponent.hoverEvent(newHoverEvent);
 			}
 		}

--- a/src/main/java/me/elian/ezauctions/helper/ItemHelper.java
+++ b/src/main/java/me/elian/ezauctions/helper/ItemHelper.java
@@ -172,7 +172,7 @@ public class ItemHelper {
 		String itemNBT = null;
 		try {
 			itemNBT = getItemNBT(itemStack).replace("minecraft:", "");
-		} catch (Exception e) {
+		} catch (Exception ignored) {
 		}
 
 		if (itemNBT == null) {

--- a/src/main/java/me/elian/ezauctions/model/AuctionData.java
+++ b/src/main/java/me/elian/ezauctions/model/AuctionData.java
@@ -35,7 +35,6 @@ public final class AuctionData {
 	private int amount;
 	private String skullOwner;
 	private int repairPrice;
-	private String itemNbt;
 	private String minecraftName;
 	private String customName;
 	private Key itemKey;
@@ -98,10 +97,6 @@ public final class AuctionData {
 		return repairPrice;
 	}
 
-	public String getItemNbt() {
-		return itemNbt;
-	}
-
 	public String getMinecraftName() {
 		return minecraftName;
 	}
@@ -128,13 +123,6 @@ public final class AuctionData {
 		}
 
 		repairPrice = ItemHelper.getXPForRepair(item);
-
-		try {
-			itemNbt = ItemHelper.getItemNbt(item).replace("minecraft:", "");
-		} catch (Exception e) {
-			itemNbt = "";
-			logger.severe("Could not get item NBT! Item hover will not work correctly!", e);
-		}
 
 		NamespacedKey typeKey = item.getType().getKey();
 		itemKey = Key.key(typeKey.getNamespace(), typeKey.getKey());


### PR DESCRIPTION
Changes:
* Update scoreboard dependency which now includes support from 1.17 to 1.21.
* Update adventure dependencies.
* Use modern PaperMC and Spigot methods for displaying item hovering in chat.
    * Can we remove the NMS method? I assume we're not supporting any versions below 1.18 anyway, correct?