### PR TITLE
Bump Scoreboard Library to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,19 +105,19 @@
         <dependency>
             <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-api</artifactId>
-            <version>2.1.10</version>
+            <version>2.2.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-implementation</artifactId>
-            <version>2.1.10</version>
+            <version>2.2.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-modern</artifactId>
-            <version>2.1.10</version>
+            <version>2.2.0</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Fixes #64.

Jar with change applied:
[ezAuctions-scoreboard-lib-bump.zip](https://github.com/user-attachments/files/17359132/ezAuctions-scoreboard-lib-bump.zip)
