### PR TITLE
Implement placeholder API expansion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <id>aikar</id>
             <url>https://repo.aikar.co/content/groups/aikar/</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/releases/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -119,6 +123,12 @@
             <artifactId>scoreboard-library-modern</artifactId>
             <version>2.2.0</version>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.6</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/elian/ezauctions/EzAuctions.java
+++ b/src/main/java/me/elian/ezauctions/EzAuctions.java
@@ -67,6 +67,10 @@ public class EzAuctions extends JavaPlugin {
 
 		updateController = injector.getInstance(UpdateController.class);
 		updateController.checkForUpdates();
+
+		if (getServer().getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+			injector.getInstance(EzAuctionsPlaceholderExpansion.class).register();
+		}
 	}
 
 	@Override

--- a/src/main/java/me/elian/ezauctions/EzAuctionsPlaceholderExpansion.java
+++ b/src/main/java/me/elian/ezauctions/EzAuctionsPlaceholderExpansion.java
@@ -60,8 +60,6 @@ public class EzAuctionsPlaceholderExpansion extends PlaceholderExpansion {
 
 		AuctionData data = auction.getAuctionData();
 
-		ItemStack item = data.getItem();
-
 		String auctioneerName = data.getAuctioneer().getOfflinePlayer().getName();
 		if (auctioneerName == null) {
 			auctioneerName = "";
@@ -84,9 +82,15 @@ public class EzAuctionsPlaceholderExpansion extends PlaceholderExpansion {
 			highestBidderName = "";
 		}
 
-		int remainingSeconds = auction.getRemainingSeconds();
-
 		String placeholder = params.toLowerCase();
+		return getAuctionPlaceholderValue(placeholder, data, auctioneerName, highestBidderName, highestBidAmount,
+				highestBidderUniqueId, auction.getRemainingSeconds());
+	}
+
+	private String getAuctionPlaceholderValue(String placeholder, AuctionData data, String auctioneerName,
+	                                          String highestBidderName, double highestBidAmount,
+	                                          String highestBidderUniqueId, int remainingSeconds) {
+		ItemStack item = data.getItem();
 		return switch (placeholder) {
 			case "auctioneer" -> auctioneerName;
 			case "auctioneeruuid" -> data.getAuctioneer().getUniqueId().toString();

--- a/src/main/java/me/elian/ezauctions/EzAuctionsPlaceholderExpansion.java
+++ b/src/main/java/me/elian/ezauctions/EzAuctionsPlaceholderExpansion.java
@@ -1,0 +1,114 @@
+package me.elian.ezauctions;
+
+import com.google.inject.Inject;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import me.elian.ezauctions.controller.AuctionController;
+import me.elian.ezauctions.controller.ConfigController;
+import me.elian.ezauctions.model.Auction;
+import me.elian.ezauctions.model.AuctionData;
+import me.elian.ezauctions.model.Bid;
+import me.elian.ezauctions.model.BidList;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class EzAuctionsPlaceholderExpansion extends PlaceholderExpansion {
+	private final Plugin plugin;
+	private final AuctionController auctionController;
+	private final ConfigController configController;
+	private final Economy economy;
+
+	@Inject
+	public EzAuctionsPlaceholderExpansion(Plugin plugin, AuctionController auctionController,
+	                                      ConfigController configController, Economy economy) {
+		this.plugin = plugin;
+		this.auctionController = auctionController;
+		this.configController = configController;
+		this.economy = economy;
+	}
+
+	@Override
+	public @NotNull String getIdentifier() {
+		return plugin.getName();
+	}
+
+	@Override
+	public @NotNull String getAuthor() {
+		return String.join(" -> ", plugin.getDescription().getAuthors());
+	}
+
+	@Override
+	public @NotNull String getVersion() {
+		return plugin.getDescription().getVersion();
+	}
+
+	@Override
+	public boolean persist() {
+		return true;
+	}
+
+	@Override
+	public @Nullable String onRequest(OfflinePlayer player, @NotNull String params) {
+		Auction auction = auctionController.getActiveAuction();
+		// if there is no active auction -> return a blank string
+		if (auction == null) {
+			return "";
+		}
+
+		AuctionData data = auction.getAuctionData();
+
+		ItemStack item = data.getItem();
+
+		String auctioneerName = data.getAuctioneer().getOfflinePlayer().getName();
+		if (auctioneerName == null) {
+			auctioneerName = "";
+		}
+
+		double highestBidAmount = data.getStartingPrice();
+		String highestBidderName = null;
+		String highestBidderUniqueId = "";
+		BidList bidList = auction.getBidList();
+		if (bidList != null) {
+			Bid highestBid = bidList.getHighestBid();
+			if (highestBid != null && !data.isSealed()) {
+				highestBidAmount = highestBid.amount();
+				highestBidderName = highestBid.auctionPlayer().getOfflinePlayer().getName();
+				highestBidderUniqueId = highestBid.auctionPlayer().getUniqueId().toString();
+			}
+		}
+
+		if (highestBidderName == null) {
+			highestBidderName = "";
+		}
+
+		int remainingSeconds = auction.getRemainingSeconds();
+
+		String placeholder = params.toLowerCase();
+		return switch (placeholder) {
+			case "auctioneer" -> auctioneerName;
+			case "auctioneeruuid" -> data.getAuctioneer().getUniqueId().toString();
+			case "itemamount" -> Integer.toString(data.getAmount());
+			case "minecraftname" -> data.getMinecraftName();
+			case "customname" -> data.getCustomName();
+			case "materialtype" -> item.getType().toString().toLowerCase();
+			case "startingprice" -> Double.toString(data.getStartingPrice());
+			case "highestbidamount" -> Double.toString(highestBidAmount);
+			case "highestbidder" -> highestBidderName;
+			case "highestbidderuuid" -> highestBidderUniqueId;
+			case "increment" -> Double.toString(data.getIncrementPrice());
+			case "starttime" -> Integer.toString(data.getStartingAuctionTime());
+			case "remainingtime" -> Integer.toString(remainingSeconds);
+			case "autobuy" -> Double.toString(data.getAutoBuyPrice());
+			case "world" -> data.getWorld();
+			case "skullowner" -> data.getSkullOwner();
+			case "repairprice" -> Integer.toString(data.getRepairPrice());
+			case "antisnipetime" -> Integer.toString(configController.getConfig().getInt("antisnipe.time"));
+			case "currencynameplural" -> economy.currencyNamePlural();
+			case "currencynamesingular" -> economy.currencyNameSingular();
+			default -> null;
+		};
+	}
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 api-version: 1.20
 authors: [Elian, Silverwolfg11]
 description: A simple, text-based auction plugin
-softdepend: [Vault]
+softdepend: [Vault, PlaceholderAPI]
 folia-supported: true
 
 permissions:


### PR DESCRIPTION
Add an internal placeholder expansion for use with the PlaceholderAPI plugin.

The following placeholders are available:
* %ezauctions_auctioneer% is the auctioneer name
* %ezauctions_auctioneeruuid% is the auctioneer uuid
* %ezauctions_itemamount% is the amount of items being auctioned
* %ezauctions_minecraftname% is the translatable minecraft name of the item being auctioned
* %ezauctions_customname% is the custom name (translatable minecraft name if no custom name specified) of the item being auctioned
* %ezauctions_materialtype% is material type of the item being auctioned
* %ezauctions_startingprice% is the starting price
* %ezauctions_highestbidamount% is the highest bid (starting price if no bids or sealed auction)
* %ezauctions_highestbidder% is the highest bidder name (blank if no bids or sealed auction)
* %ezauctions_highestbidderuuid% is the highest bidder uuid (blank if no bids or sealed auction)
* %ezauctions_increment% is the increment
* %ezauctions_starttime% is the start time of the auction
* %ezauctions_remainingtime% is the remaining time of the auction
* %ezauctions_autobuy% is the autobuy price
* %ezauctions_world% is the world of the auction
* %ezauctions_skullowner% is the player who the skull belongs to
* %ezauctions_repairprice% is the repair price
* %ezauctions_antisnipetime% is the amount of time to be added when an antisnipe is triggered config: antisnipe.time
* %ezauctions_currencynamesingular% is the currency name singular/currency prefix from vault. your economy provider needs to support this
* %ezauctions_currencynameplural% is the currency name plural/currency prefix from vault. your economy provider needs to support this