### PR TITLE
Adding static getHandlerList to the events

### DIFF
--- a/src/main/java/me/elian/ezauctions/event/AuctionBidEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionBidEvent.java
@@ -43,4 +43,8 @@ public class AuctionBidEvent extends Event implements Cancellable {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }

--- a/src/main/java/me/elian/ezauctions/event/AuctionCancelEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionCancelEvent.java
@@ -43,4 +43,8 @@ public class AuctionCancelEvent extends Event implements Cancellable {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }

--- a/src/main/java/me/elian/ezauctions/event/AuctionEndEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionEndEvent.java
@@ -25,4 +25,8 @@ public class AuctionEndEvent extends Event {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }

--- a/src/main/java/me/elian/ezauctions/event/AuctionImpoundEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionImpoundEvent.java
@@ -43,4 +43,8 @@ public class AuctionImpoundEvent extends Event implements Cancellable {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }

--- a/src/main/java/me/elian/ezauctions/event/AuctionQueueEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionQueueEvent.java
@@ -35,4 +35,8 @@ public class AuctionQueueEvent extends Event implements Cancellable {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }

--- a/src/main/java/me/elian/ezauctions/event/AuctionStartEvent.java
+++ b/src/main/java/me/elian/ezauctions/event/AuctionStartEvent.java
@@ -36,4 +36,8 @@ public class AuctionStartEvent extends Event implements Cancellable {
 	public @NotNull HandlerList getHandlers() {
 		return handlers;
 	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
 }


### PR DESCRIPTION
It is required to use method HandlerList.unregisterAll(Listener).