### PR TITLE
Fix item delivery failure on high player count Folia servers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,10 @@
                             <pattern>net.megavex.scoreboardlibrary</pattern>
                             <shadedPattern>me.elian.ezauctions.scoreboardlibrary</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>com.j256.ormlite</pattern>
+                            <shadedPattern>me.elian.ezauctions.ormlite</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
                 <executions>

--- a/src/main/java/me/elian/ezauctions/controller/AuctionPlayerController.java
+++ b/src/main/java/me/elian/ezauctions/controller/AuctionPlayerController.java
@@ -73,7 +73,7 @@ public class AuctionPlayerController implements Listener {
 	}
 
 	public @NotNull List<AuctionPlayer> getOnlinePlayers() {
-		return Collections.unmodifiableList(onlinePlayers);
+		return new ArrayList<>(onlinePlayers);
 	}
 
 	@EventHandler

--- a/src/main/java/me/elian/ezauctions/controller/AuctionPlayerController.java
+++ b/src/main/java/me/elian/ezauctions/controller/AuctionPlayerController.java
@@ -1,5 +1,6 @@
 package me.elian.ezauctions.controller;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import me.elian.ezauctions.Logger;
@@ -20,10 +21,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 @Singleton
@@ -34,7 +32,7 @@ public class AuctionPlayerController implements Listener {
 	private final ConfigController config;
 	private final MessageController messages;
 	private final ScoreboardController scoreboard;
-	private final List<AuctionPlayer> onlinePlayers = new ArrayList<>();
+	private final Set<AuctionPlayer> onlinePlayers = Sets.newConcurrentHashSet();
 
 	@Inject
 	public AuctionPlayerController(Plugin plugin, Logger logger, Database database, TaskScheduler scheduler,
@@ -72,8 +70,8 @@ public class AuctionPlayerController implements Listener {
 		scheduler.runAsyncTask(() -> database.saveAuctionPlayer(auctionPlayer));
 	}
 
-	public @NotNull List<AuctionPlayer> getOnlinePlayers() {
-		return new ArrayList<>(onlinePlayers);
+	public @NotNull Set<AuctionPlayer> getOnlinePlayers() {
+		return Collections.unmodifiableSet(onlinePlayers);
 	}
 
 	@EventHandler

--- a/src/main/java/me/elian/ezauctions/controller/MessageController.java
+++ b/src/main/java/me/elian/ezauctions/controller/MessageController.java
@@ -112,7 +112,7 @@ public class MessageController extends FileHandler {
 		sendComponentToSender(target, message);
 	}
 
-	public void broadcastAuctionMessage(@NotNull List<AuctionPlayer> onlinePlayers, @NotNull Auction auction,
+	public void broadcastAuctionMessage(@NotNull Set<AuctionPlayer> onlinePlayers, @NotNull Auction auction,
 	                                    boolean spammy, @NotNull String key, @Nullable TagResolver... resolvers) {
 		UUID auctioneerId = auction.getAuctionData().getAuctioneer().getUniqueId();
 		String world = auction.getAuctionData().getWorld();

--- a/src/main/java/me/elian/ezauctions/controller/ScoreboardController.java
+++ b/src/main/java/me/elian/ezauctions/controller/ScoreboardController.java
@@ -18,6 +18,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.Set;
 
 @Singleton
 public class ScoreboardController implements Listener {
@@ -43,7 +44,7 @@ public class ScoreboardController implements Listener {
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 
-	public void createForAuction(@NotNull Auction auction, @NotNull List<AuctionPlayer> onlinePlayers) {
+	public void createForAuction(@NotNull Auction auction, @NotNull Set<AuctionPlayer> onlinePlayers) {
 		if (!config.getConfig().getBoolean("scoreboard.enabled"))
 			return;
 
@@ -106,7 +107,7 @@ public class ScoreboardController implements Listener {
 		scoreboardLibrary.close();
 	}
 
-	private void createSidebar(@NotNull List<AuctionPlayer> onlinePlayers) {
+	private void createSidebar(@NotNull Set<AuctionPlayer> onlinePlayers) {
 		sidebar = scoreboardLibrary.createSidebar();
 
 		for (AuctionPlayer auctionPlayer : onlinePlayers) {


### PR DESCRIPTION
On Folia servers with a high number of players and constant join/leaves, the plugin can break due to concurrency issues with the AuctionPlayer list. This error prevents payouts and item delivery due to design decisions in those parts of the plugin.

This PR also moves the ORM to its own safe shaded location to prevent conflicts at runtime that may have been causing spontaneous failures on my server, though it's unclear. Will open a separate issue.

This PR changes to a concurrency-tolerant set to improve reliability. I would still recommend 

```
[18:12:10] [Folia Async Scheduler Thread #1552/ERROR]: [ezAuctions] Exception occurred while processing task!
java.util.ConcurrentModificationException: null
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1095) ~[?:?]
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:1049) ~[?:?]
	at java.base/java.util.Collections$UnmodifiableCollection$1.next(Collections.java:1078) ~[?:?]
	at ezAuctions.jar/me.elian.ezauctions.controller.MessageController.broadcastAuctionMessage(MessageController.java:122) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.model.Auction.handleAuctionTimeCompleted(Auction.java:227) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.model.Auction.end(Auction.java:147) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.model.BidList.placeBid(BidList.java:94) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.command.BidCommand.tryPlaceBid(BidCommand.java:167) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.command.BidCommand.lambda$bid$0(BidCommand.java:99) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.model.BidList.withSync(BidList.java:24) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.command.BidCommand.lambda$bid$1(BidCommand.java:99) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.scheduler.TaskSchedulerBase.lambda$wrapRunnable$1(TaskSchedulerBase.java:153) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.scheduler.TaskSchedulerBase.lambda$runAsyncPlayerCommandTask$0(TaskSchedulerBase.java:55) ~[ezAuctions.jar:?]
	at ezAuctions.jar/me.elian.ezauctions.scheduler.ThreadedRegionTaskScheduler.lambda$scheduleAsyncTask$2(ThreadedRegionTaskScheduler.java:42) ~[ezAuctions.jar:?]
	at io.papermc.paper.threadedregions.scheduler.FoliaAsyncScheduler$AsyncScheduledTask.run(FoliaAsyncScheduler.java:217) ~[folia-1.21.4.jar:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```