### PR TITLE
Don't drop items on shutdown

### DIFF
--- a/src/main/java/me/elian/ezauctions/controller/AuctionController.java
+++ b/src/main/java/me/elian/ezauctions/controller/AuctionController.java
@@ -176,14 +176,14 @@ public class AuctionController implements Listener {
 
 	public void shutdown() {
 		for (AuctionData queued : auctionQueue) {
-			queued.giveItemToPlayer(queued.getAuctioneer(), playerController, scheduler, config, messages);
+			queued.addSavedItemToPlayer(queued.getAuctioneer(), playerController, scheduler);
 		}
 
 		auctionQueue.clear();
 
 		Auction activeAuction = getActiveAuction();
 		if (activeAuction != null) {
-			activeAuction.cancelAuction(true);
+			activeAuction.cancelAuctionShutdown();
 		}
 	}
 

--- a/src/main/java/me/elian/ezauctions/model/Auction.java
+++ b/src/main/java/me/elian/ezauctions/model/Auction.java
@@ -118,6 +118,22 @@ public class Auction implements Runnable {
 		}
 	}
 
+	public void cancelAuctionShutdown() {
+		synchronized (this) {
+			if (!running)
+				return;
+
+			cancelRepeatingTask();
+			messages.broadcastAuctionMessage(playerController.getOnlinePlayers(),
+					this, false, "auction.cancelled");
+			auctionData.addSavedItemToPlayer(auctionData.getAuctioneer(), playerController, scheduler);
+
+			returnStartPriceToAuctioneer();
+
+			returnBidderMoney(true);
+		}
+	}
+
 	public void impoundAuction(@NotNull AuctionPlayer impoundingPlayer) {
 		synchronized (this) {
 			if (!running)

--- a/src/main/java/me/elian/ezauctions/model/AuctionData.java
+++ b/src/main/java/me/elian/ezauctions/model/AuctionData.java
@@ -357,7 +357,7 @@ public final class AuctionData {
 		return true;
 	}
 
-	private void addSavedItemToPlayer(AuctionPlayer auctionPlayer, AuctionPlayerController playerController,
+	public void addSavedItemToPlayer(AuctionPlayer auctionPlayer, AuctionPlayerController playerController,
 	                                  TaskScheduler scheduler) {
 		scheduler.runAsyncTask(() -> playerController.getPlayerFromDatabase(auctionPlayer.getUniqueId())
 				.thenAccept((newAuctionPlayer) -> {


### PR DESCRIPTION
- Dropping items on shutdown can cause issues when server is crashing, specifically with Folio. Regardless, it is safer to just store the item in the database for server reboot/player log in. Fix for #71