### PR TITLE
Fix thread starvation due to infinite "connecting" state

### DIFF
--- a/src/main/java/me/elian/ezauctions/data/OrmLiteDatabase.java
+++ b/src/main/java/me/elian/ezauctions/data/OrmLiteDatabase.java
@@ -150,7 +150,7 @@ public class OrmLiteDatabase implements Database {
 					TableUtils.createTableIfNotExists(connectionSource, AuctionPlayerIgnore.class);
 					TableUtils.createTableIfNotExists(connectionSource, SavedItem.class);
 				}
-
+				connecting = false;
 				connectingMonitor.notifyAll();
 			} catch (Exception e) {
 				connecting = false;


### PR DESCRIPTION
During a "reconnect", the "connecting" state is never set back to `false`. This results in async threads slowly being starved from the server, eventually causing a weird partially crashed state on the affected server. This PR corrects this behavior and sets "connecting" to false, allowing saveAuctionPlayer to finish executing.

Previous behavior ("Frozen Threads" tab in YourKit):
<img width="1030" height="686" alt="image" src="https://github.com/user-attachments/assets/c5345b6a-061d-4e83-a235-2778dbd025cd" />
