### PR TITLE
Bump scoreboard library version, make load errors logged to console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,12 +144,6 @@
             <scope>runtime</scope>
         </dependency>
         <dependency>
-            <groupId>net.megavex</groupId>
-            <artifactId>scoreboard-library-modern</artifactId>
-            <version>2.2.0</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>me.clip</groupId>
             <artifactId>placeholderapi</artifactId>
             <version>2.11.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,13 +134,13 @@
         <dependency>
             <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-api</artifactId>
-            <version>2.2.0</version>
+            <version>2.7.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>net.megavex</groupId>
             <artifactId>scoreboard-library-implementation</artifactId>
-            <version>2.2.0</version>
+            <version>2.7.4</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/elian/ezauctions/controller/ScoreboardController.java
+++ b/src/main/java/me/elian/ezauctions/controller/ScoreboardController.java
@@ -2,6 +2,7 @@ package me.elian.ezauctions.controller;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import me.elian.ezauctions.Logger;
 import me.elian.ezauctions.model.Auction;
 import me.elian.ezauctions.model.AuctionPlayer;
 import me.elian.ezauctions.scheduler.TaskScheduler;
@@ -30,15 +31,24 @@ public class ScoreboardController implements Listener {
 
 	@Inject
 	public ScoreboardController(TaskScheduler scheduler, ConfigController config, MessageController messages,
-	                            Plugin plugin) {
+	                            Plugin plugin, Logger logger) {
 		this.scheduler = scheduler;
 		this.config = config;
 		this.messages = messages;
 
 		try {
+			// force scoreboardlib to load even when plugin not using latest library version
+			String property = "net.mega".concat("vex.scoreboardlibrary.forceModern");
+			System.setProperty(property, "true");
 			scoreboardLibrary = ScoreboardLibrary.loadScoreboardLibrary(plugin);
-		} catch (Exception e) {
+		} catch (NoPacketAdapterAvailableException e) {
 			scoreboardLibrary = new NoopScoreboardLibrary();
+			logger.severe("Scoreboard functionality will not be visible due to server version not being " +
+					"supported. If you are running the latest ezAuctions, please report this issue on GitHub.", e);
+		} catch (RuntimeException e) {
+			scoreboardLibrary = new NoopScoreboardLibrary();
+			logger.info("Scoreboard functionality will not be visible due to error with plugin build. " +
+					"This is normal when run in a test.");
 		}
 
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 api-version: 1.20
 authors: [Elian, Silverwolfg11]
 description: A simple, text-based auction plugin
-softdepend: [Vault, PlaceholderAPI]
+softdepend: [Vault, PlaceholderAPI, ViaVersion]
 folia-supported: true
 
 permissions:


### PR DESCRIPTION
Fixes #78.
- Updated the scoreboard library to 2.7.4
- Removed unnecessary scoreboard library dependency
- Log scoreboard load errors
- Set forceModern property for scoreboard load to allow it to continue with future versions